### PR TITLE
Enhance http sink task tests and remove body when http method does not permit one

### DIFF
--- a/src/main/java/com/github/clescot/kafka/connect/http/HttpRequest.java
+++ b/src/main/java/com/github/clescot/kafka/connect/http/HttpRequest.java
@@ -12,70 +12,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
-@io.confluent.kafka.schemaregistry.annotations.Schema(value = "{\n" +
-        "  \"$schema\": \"http://json-schema.org/draft/2019-09/schema#\",\n" +
-        "  \"title\": \"Http Request schema to drive HTTP Sink Connector\",\n" +
-        "  \"description\": \"Http Request schema to drive HTTP Sink Connector. It supports 3 modes : classical body as string (bodyPart set to 'STRING'), a Map<String,String> mode to fill HTML form, a byte Array mode to transmit binary data((bodyPart set to 'BYTE_ARRAY'), and a multipart mode ((bodyPart set to 'MULTIPART')\",\n" +
-        "  \"type\": \"object\",\n" +
-        "  \"additionalProperties\": false,\n" +
-        "  \"required\": [\"url\",\"method\",\"bodyType\"],\n" +
-        "  \"properties\": {\n" +
-        "    \"url\": {\n" +
-        "      \"type\": \"string\"\n" +
-        "    },\n" +
-        "    \"headers\": {\n" +
-        "      \"type\": \"object\",\n" +
-        "      \"connect.type\": \"map\",\n" +
-        "      \"additionalProperties\": {\n" +
-        "        \"type\": \"array\",\n" +
-        "        \"items\": {\n" +
-        "          \"type\": \"string\"\n" +
-        "        }\n" +
-        "      }\n" +
-        "    },\n" +
-        "    \"method\": {\n" +
-        "      \"type\": \"string\"\n" +
-        "    },\n" +
-        "    \"bodyAsString\":\n" +
-        "        {\n" +
-        "          \"type\": \"string\"\n" +
-        "        }\n" +
-        "      ,\n" +
-        "    \"bodyAsForm\":\n" +
-        "        {\n" +
-        "          \"type\": \"object\",\n" +
-        "          \"connect.type\": \"map\",\n" +
-        "          \"additionalProperties\": { \"type\": \"string\" }\n" +
-        "        }\n" +
-        "      ,\n" +
-        "    \"bodyAsByteArray\":  {\n" +
-        "          \"type\": \"string\"\n" +
-        "    },\n" +
-        "    \"bodyAsMultipart\": {\n" +
-        "          \"type\": \"array\",\n" +
-        "          \"items\": {\n" +
-        "            \"type\": \"string\"\n" +
-        "          }\n" +
-        "    },\n" +
-        "    \"bodyType\": {\n" +
-        "      \"type\": \"string\",\n" +
-        "      \"enum\": [\n" +
-        "        \"STRING\",\n" +
-        "        \"BYTE_ARRAY\",\n" +
-        "        \"MULTIPART\"\n" +
-        "      ]\n" +
-        "    }\n" +
-        "  },\n" +
-        "  \"required\": [\n" +
-        "    \"url\",\n" +
-        "    \"method\",\n" +
-        "    \"bodyType\"\n" +
-        "  ]\n" +
-        "}",
+@io.confluent.kafka.schemaregistry.annotations.Schema(value = HttpRequest.SCHEMA_AS_STRING,
         refs = {})
 public class HttpRequest {
 
-
+    public static final String test="";
     public static final String URL = "url";
     public static final String METHOD = "method";
     public static final String HEADERS = "headers";
@@ -109,7 +50,67 @@ public class HttpRequest {
     @JsonProperty
     private BodyType bodyType;
 
-
+    public static final String SCHEMA_AS_STRING = "{\n" +
+            "  \"$id\": \"https://github.com/clescot/kafka-connect-http-sink/schemas/http-request\",\n" +
+            "  \"$schema\": \"http://json-schema.org/draft/2019-09/schema\",\n" +
+            "  \"title\": \"Http Request schema to drive HTTP Sink Connector\",\n" +
+            "  \"description\": \"Http Request schema to drive HTTP Sink Connector. It supports 3 modes : classical body as string (bodyPart set to 'STRING'), a Map<String,String> mode to fill HTML form, a byte Array mode to transmit binary data((bodyPart set to 'BYTE_ARRAY'), and a multipart mode ((bodyPart set to 'MULTIPART')\",\n" +
+            "  \"type\": \"object\",\n" +
+            "  \"additionalProperties\": false,\n" +
+            "  \"required\": [\"url\",\"method\",\"bodyType\"],\n" +
+            "  \"properties\": {\n" +
+            "    \"url\": {\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    \"headers\": {\n" +
+            "      \"type\": \"object\",\n" +
+            "      \"connect.type\": \"map\",\n" +
+            "      \"additionalProperties\": {\n" +
+            "        \"type\": \"array\",\n" +
+            "        \"items\": {\n" +
+            "          \"type\": \"string\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"method\": {\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    \"bodyAsString\":\n" +
+            "    {\n" +
+            "      \"type\": \"string\"\n" +
+            "    }\n" +
+            "  ,\n" +
+            "    \"bodyAsForm\":\n" +
+            "    {\n" +
+            "      \"type\": \"object\",\n" +
+            "      \"connect.type\": \"map\",\n" +
+            "      \"additionalProperties\": { \"type\": \"string\" }\n" +
+            "    }\n" +
+            "  ,\n" +
+            "    \"bodyAsByteArray\":  {\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    \"bodyAsMultipart\": {\n" +
+            "      \"type\": \"array\",\n" +
+            "      \"items\": {\n" +
+            "        \"type\": \"string\"\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"bodyType\": {\n" +
+            "      \"type\": \"string\",\n" +
+            "      \"enum\": [\n" +
+            "        \"STRING\",\n" +
+            "        \"BYTE_ARRAY\",\n" +
+            "        \"MULTIPART\"\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"required\": [\n" +
+            "    \"url\",\n" +
+            "    \"method\",\n" +
+            "    \"bodyType\"\n" +
+            "  ]\n" +
+            "}";
     public static final Schema SCHEMA = SchemaBuilder
             .struct()
             .name(HttpRequest.class.getName())

--- a/src/main/java/com/github/clescot/kafka/connect/http/sink/HttpSinkTask.java
+++ b/src/main/java/com/github/clescot/kafka/connect/http/sink/HttpSinkTask.java
@@ -265,7 +265,7 @@ public class HttpSinkTask extends SinkTask {
     }
 
 
-    private HttpRequest addTrackingHeaders(HttpRequest httpRequest) {
+    protected HttpRequest addTrackingHeaders(HttpRequest httpRequest) {
         if (httpRequest == null) {
             LOGGER.warn("sinkRecord has got a 'null' value");
             throw new ConnectException("sinkRecord has got a 'null' value");
@@ -299,16 +299,17 @@ public class HttpSinkTask extends SinkTask {
         String stringValue = null;
         try {
             Class<?> valueClass = value.getClass();
-            LOGGER.debug("valueClass is {}", valueClass.getName());
+            LOGGER.debug("valueClass is '{}'", valueClass.getName());
+            LOGGER.debug("value Schema from SinkRecord is '{}'", sinkRecord.valueSchema());
             if (Struct.class.isAssignableFrom(valueClass)) {
                 Struct valueAsStruct = (Struct) value;
                 LOGGER.debug("Struct is {}", valueAsStruct);
                 valueAsStruct.validate();
                 Schema schema = valueAsStruct.schema();
                 String schemaTypeName = schema.type().getName();
-                LOGGER.debug("schema type name from Struct is {}", schemaTypeName);
+                LOGGER.debug("schema type name referenced in Struct is '{}'", schemaTypeName);
                 Integer version = schema.version();
-                LOGGER.debug("schema version from Struct is {}", version);
+                LOGGER.debug("schema version referenced in Struct is '{}'", version);
 
                 httpRequest = HttpRequest
                         .Builder
@@ -356,7 +357,7 @@ public class HttpSinkTask extends SinkTask {
         return httpRequest;
     }
 
-    private HttpRequest addStaticHeaders(HttpRequest httpRequest) {
+    protected HttpRequest addStaticHeaders(HttpRequest httpRequest) {
         Preconditions.checkNotNull(httpRequest,"httpRequest is null");
         this.staticRequestHeaders.forEach((key, value) -> httpRequest.getHeaders().put(key, value));
         return httpRequest;

--- a/src/test/java/com/github/clescot/kafka/connect/http/sink/client/okhttp/OkHttpClientTest.java
+++ b/src/test/java/com/github/clescot/kafka/connect/http/sink/client/okhttp/OkHttpClientTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Maps;
 import okhttp3.*;
 import okhttp3.internal.http.RealResponseBody;
 import okio.Buffer;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,13 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OkHttpClientTest {
 
     private Logger LOGGER = LoggerFactory.getLogger(OkHttpClientTest.class);
+
     @Test
-    public void test_build_request() throws IOException {
+    public void test_build_POST_request() throws IOException {
         OkHttpClient client = new OkHttpClient(Maps.newHashMap());
-        HttpRequest httpRequest = new HttpRequest("http://dummy.com/","POST",HttpRequest.BodyType.STRING.name());
+        HttpRequest httpRequest = new HttpRequest("http://dummy.com/", "POST", HttpRequest.BodyType.STRING.name());
         httpRequest.setBodyAsString("stuff");
         Request request = client.buildRequest(httpRequest);
-        LOGGER.debug("request:{}",request);
+        LOGGER.debug("request:{}", request);
         assertThat(request.url().url().toString()).isEqualTo(httpRequest.getUrl());
         assertThat(request.method()).isEqualTo(httpRequest.getMethod());
         RequestBody body = request.body();
@@ -33,33 +35,45 @@ class OkHttpClientTest {
         assertThat(buffer.readUtf8()).isEqualTo(httpRequest.getBodyAsString());
     }
 
+
+    @Test
+    public void test_build_GET_request_with_body() {
+        OkHttpClient client = new OkHttpClient(Maps.newHashMap());
+        HttpRequest httpRequest = new HttpRequest("http://dummy.com/", "GET", HttpRequest.BodyType.STRING.name());
+        httpRequest.setBodyAsString("stuff");
+        Request request = client.buildRequest(httpRequest);
+        LOGGER.debug("request:{}", request);
+        assertThat(request.url().url().toString()).isEqualTo(httpRequest.getUrl());
+        assertThat(request.method()).isEqualTo(httpRequest.getMethod());
+        assertThat(request.body()).isNull();
+    }
+
     @Test
     public void test_build_response() {
         OkHttpClient client = new OkHttpClient(Maps.newHashMap());
 
-
-        HttpRequest httpRequest = new HttpRequest("http://dummy.com/","POST",HttpRequest.BodyType.STRING.name());
+        HttpRequest httpRequest = new HttpRequest("http://dummy.com/", "POST", HttpRequest.BodyType.STRING.name());
         httpRequest.setBodyAsString("stuff");
         Request request = client.buildRequest(httpRequest);
 
         Response.Builder builder = new Response.Builder();
         Headers headers = new Headers.Builder()
-                .add("key1","value1")
-                .add("Content-Type","application/json")
+                .add("key1", "value1")
+                .add("Content-Type", "application/json")
                 .build();
         builder.headers(headers);
         builder.request(request);
         builder.code(200);
         builder.message("OK");
-        String responseContent="blabla";
+        String responseContent = "blabla";
         Buffer buffer = new Buffer();
         buffer.write(responseContent.getBytes(StandardCharsets.UTF_8));
-        ResponseBody responseBody = new RealResponseBody("application/json",responseContent.length(),buffer);
+        ResponseBody responseBody = new RealResponseBody("application/json", responseContent.length(), buffer);
         builder.body(responseBody);
         builder.protocol(Protocol.HTTP_1_1);
         Response response = builder.build();
         HttpResponse httpResponse = client.buildResponse(response);
-        LOGGER.debug("response:{}",response);
+        LOGGER.debug("response:{}", response);
         assertThat(response.code()).isEqualTo(httpResponse.getStatusCode());
         assertThat(response.message()).isEqualTo(httpResponse.getStatusMessage());
         assertThat(response.header("key1")).isEqualTo(httpResponse.getResponseHeaders().get("key1").get(0));

--- a/src/test/resources/http-exchange.json
+++ b/src/test/resources/http-exchange.json
@@ -1,8 +1,8 @@
 {
-  "$id": "https://github.com/clescot/kafka-connect-http-sink/schemas/http-exchange",
-  "$schema": "http://json-schema.org/draft/2019-09/schema",
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
   "title": "Http Exchange",
   "type": "object",
+  "javaType" : "com.github.clescot.kafka.connect.http.HttpExchange",
   "additionalProperties": false,
   "properties": {
     "durationInMillis": {

--- a/src/test/resources/http-request.json
+++ b/src/test/resources/http-request.json
@@ -1,9 +1,9 @@
 {
-  "$id": "https://github.com/clescot/kafka-connect-http-sink/schemas/http-request",
-  "$schema": "http://json-schema.org/draft/2019-09/schema",
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
   "title": "Http Request schema to drive HTTP Sink Connector",
   "description": "Http Request schema to drive HTTP Sink Connector. It supports 3 modes : classical body as string (bodyPart set to 'STRING'), a Map<String,String> mode to fill HTML form, a byte Array mode to transmit binary data((bodyPart set to 'BYTE_ARRAY'), and a multipart mode ((bodyPart set to 'MULTIPART')",
   "type": "object",
+  "javaType" : "com.github.clescot.kafka.connect.http.HttpRequest",
   "additionalProperties": false,
   "required": ["url","method","bodyType"],
   "properties": {
@@ -12,6 +12,7 @@
     },
     "headers": {
       "type": "object",
+      "existingJavaType" : "java.util.Map<String,java.util.List<String>>",
       "connect.type": "map",
       "additionalProperties": {
         "type": "array",
@@ -32,7 +33,7 @@
     {
       "type": "object",
       "connect.type": "map",
-      "additionalProperties": { "type": "string" }
+      "existingJavaType" : "java.util.Map<String,String>"
     }
   ,
     "bodyAsByteArray":  {

--- a/src/test/resources/http-response.json
+++ b/src/test/resources/http-response.json
@@ -1,9 +1,9 @@
 {
-  "$id": "https://github.com/clescot/kafka-connect-http-sink/schemas/http-response",
-  "$schema": "http://json-schema.org/draft/2019-09/schema",
+  "$schema": "http://json-schema.org/draft/2019-09/schema#",
   "title": "Http Response schema.",
   "description": "Http Response schema, included into HttpExchange.",
   "type": "object",
+  "javaType" : "com.github.clescot.kafka.connect.http.HttpResponse",
   "additionalProperties": false,
   "properties": {
     "statusCode":{
@@ -14,6 +14,7 @@
     },
     "responseHeaders":  {
       "type": "object",
+      "existingJavaType" : "java.util.Map<String,java.util.List<String>>",
       "additionalProperties": {
         "type": "array",
         "items": {


### PR DESCRIPTION
t prevent an error, remove body when HTTP methods does not permit one like HEAD and GET methods in the okhttp HTTPClient.